### PR TITLE
Fixed modals

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,8 @@ import { AppRoutingModule } from './app-routing.module';
 import { ModalService } from './services/modal.service';
 import { DomService } from './services/dom.service';
 import { SharedModule } from './common/shared.module';
+import { MenuCreateSummaryComponent } from './main/menu/create/summary/menu-create-summary.component';
+import { MenuCreateFoodComponent } from './main/menu/create/food/menu-create-food.component';
 
 const jwtModuleOptions: JwtModuleOptions = {
   config: {
@@ -24,6 +26,10 @@ const jwtModuleOptions: JwtModuleOptions = {
   declarations: [
     AppComponent,
     LoginComponent,
+
+    // for entryComponents, as those cannot be declared in submodules
+    MenuCreateSummaryComponent,
+    MenuCreateFoodComponent,
   ],
   imports: [
     AppRoutingModule,
@@ -50,5 +56,9 @@ const jwtModuleOptions: JwtModuleOptions = {
     ModalService,
   ],
   bootstrap: [AppComponent],
+  entryComponents: [
+    MenuCreateSummaryComponent,
+    MenuCreateFoodComponent,
+  ],
 })
 export class AppModule {}

--- a/src/app/main/menu/menu.module.ts
+++ b/src/app/main/menu/menu.module.ts
@@ -2,8 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FoodDetailsComponent } from './food/detail/food-details.component';
 import { MenuCreateComponent } from './create/menu-create.component';
-import { MenuCreateFoodComponent } from './create/food/menu-create-food.component';
-import { MenuCreateSummaryComponent } from './create/summary/menu-create-summary.component';
 import { MenuDetailsComponent } from './details/menu-details.component';
 import { MenuListComponent } from './list/menu-list.component';
 import { SharedModule } from '../../common/shared.module';
@@ -14,8 +12,6 @@ import { MenuRoutingModule } from './menu-routing.module';
   declarations: [
     FoodDetailsComponent,
     MenuCreateComponent,
-    MenuCreateFoodComponent,
-    MenuCreateSummaryComponent,
     MenuDetailsComponent,
     MenuListComponent,
   ],
@@ -24,10 +20,6 @@ import { MenuRoutingModule } from './menu-routing.module';
     FormsModule,
     MenuRoutingModule,
     SharedModule,
-  ],
-  entryComponents: [
-    MenuCreateSummaryComponent,
-    MenuCreateFoodComponent,
   ],
 })
 export class MenuModule { }


### PR DESCRIPTION
Lazy loaded modules cannot declare `entryComponents`, currently only workaround is to declare them in `AppModule`